### PR TITLE
implement querying of variant runtime/build deps

### DIFF
--- a/pdc/apps/tree/migrations/0002_builddependency_runtimedependency.py
+++ b/pdc/apps/tree/migrations/0002_builddependency_runtimedependency.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tree', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BuildDependency',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('dependency', models.CharField(max_length=300)),
+                ('variant', models.ForeignKey(related_name='build_deps', to='tree.UnreleasedVariant')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='RuntimeDependency',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('dependency', models.CharField(max_length=300)),
+                ('variant', models.ForeignKey(related_name='runtime_deps', to='tree.UnreleasedVariant')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/pdc/apps/tree/models.py
+++ b/pdc/apps/tree/models.py
@@ -35,6 +35,27 @@ class UnreleasedVariant(models.Model): # Not the variant from compose ... which 
             'koji_tag': self.koji_tag
         }
 
+
+class VariantDependency(models.Model):
+
+    dependency = models.CharField(max_length=300)
+
+    class Meta:
+        abstract = True
+
+
+class RuntimeDependency(VariantDependency):
+
+    variant = models.ForeignKey("UnreleasedVariant",
+                                related_name="runtime_deps")
+
+
+class BuildDependency(VariantDependency):
+
+    variant = models.ForeignKey("UnreleasedVariant",
+                                related_name="build_deps")
+
+
 class Tree(models.Model):
     tree_id             = models.CharField(max_length=200, unique=True)
     tree_date           = models.DateField()

--- a/pdc/apps/tree/serializers.py
+++ b/pdc/apps/tree/serializers.py
@@ -78,8 +78,8 @@ class UnreleasedVariantSerializer(StrictSerializerMixin,
     variant_version     = serializers.CharField(max_length=100)
     variant_release     = serializers.CharField(max_length=100)
     koji_tag            = serializers.CharField(max_length=300)
-    runtime_deps        = RuntimeDepSerializer(many=True)
-    build_deps          = BuildDepSerializer(many=True)
+    runtime_deps        = RuntimeDepSerializer(many=True, required=False)
+    build_deps          = BuildDepSerializer(many=True, required=False)
 
     class Meta:
         model = UnreleasedVariant


### PR DESCRIPTION
At the moment, this is needed to model dependencies between variants of
the type 'module', it doesn't implement updating of existing
UnreleasedVariants yet (not sure if we want/need that).

Signed-off-by: Nils Philippsen nils@redhat.com
