### PR TITLE
Shame! fix RelatedManager not iterable by iterating over .all()

### DIFF
--- a/pdc/apps/tree/models.py
+++ b/pdc/apps/tree/models.py
@@ -34,8 +34,8 @@ class UnreleasedVariant(models.Model): # Not the variant from compose ... which 
             'variant_version': self.variant_version,
             'variant_release': self.variant_release,
             'koji_tag': self.koji_tag,
-            'runtime_deps': [ v.dependency for v in self.runtime_deps ],
-            'build_deps': [ v.dependency for v in self.build_deps ],
+            'runtime_deps': [ v.dependency for v in self.runtime_deps.all() ],
+            'build_deps': [ v.dependency for v in self.build_deps.all() ],
         }
 
 


### PR DESCRIPTION
I did forget on .all() in export ... adding dependencies trough variant_dict fails on this. All works fine after applying this fix
