### PR TITLE
Add filters for build_deps and runtime_deps.

### DIFF
--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -90,17 +90,20 @@ class FindComposeByReleaseRPMTestCase(APITestCase):
                 {'name': u'bash', 'version': u'1.2.3', 'epoch': 0, 'release': u'4.b1',
                  'arch': u'x86_64', 'srpm_name': u'bash', 'srpm_nevra': u'bash-0:1.2.3-4.b1.src',
                  'filename': 'bash-1.2.3-4.b1.x86_64.rpm', 'id': 1, 'built_for_release': None,
-                 'linked_composes': ['compose-1', 'compose-2'], 'linked_releases': []}]},
+                 'linked_composes': ['compose-1', 'compose-2'], 'linked_releases': [],
+                 'srpm_commit_hash': None, 'srpm_commit_branch': None}]},
             {'compose': u'compose-2', 'packages': [
                 {'name': u'bash', 'version': u'1.2.3', 'epoch': 0, 'release': u'4.b1',
                  'arch': u'x86_64', 'srpm_name': u'bash', 'srpm_nevra': u'bash-0:1.2.3-4.b1.src',
                  'filename': 'bash-1.2.3-4.b1.x86_64.rpm', 'id': 1, 'built_for_release': None,
-                 'linked_composes': ['compose-1', 'compose-2'], 'linked_releases': []}]},
+                 'linked_composes': ['compose-1', 'compose-2'], 'linked_releases': [],
+                 'srpm_commit_hash': None, 'srpm_commit_branch': None}]},
             {'compose': u'compose-3', 'packages': [
                 {'name': u'bash', 'version': u'5.6.7', 'epoch': 0, 'release': u'8',
                  'arch': u'x86_64', 'srpm_name': u'bash', 'srpm_nevra': None,
                  'filename': 'bash-5.6.7-8.x86_64.rpm', 'id': 2, 'built_for_release': None,
-                 'linked_composes': ['compose-3'], 'linked_releases': []}]}
+                 'linked_composes': ['compose-3'], 'linked_releases': [],
+                 'srpm_commit_hash': None, 'srpm_commit_branch': None}]}
         ]
         self.assertEqual(response.data, expected)
 
@@ -164,6 +167,7 @@ class FindOlderComposeByComposeRPMTestCase(APITestCase):
             dict(packages[0]),
             {'name': 'bash', 'version': '1.2.3', 'epoch': 0, 'release': '4.b1',
              'arch': 'x86_64', 'srpm_name': 'bash', 'srpm_nevra': 'bash-0:1.2.3-4.b1.src', 'built_for_release': None,
+             "srpm_commit_hash": None, "srpm_commit_branch": None,
              'filename': 'bash-1.2.3-4.b1.x86_64.rpm'})
 
     def test_same_version_different_arch(self):

--- a/pdc/apps/package/filters.py
+++ b/pdc/apps/package/filters.py
@@ -67,6 +67,8 @@ class RPMFilter(django_filters.FilterSet):
     filename    = MultiValueFilter()
     compose     = MultiValueFilter(name='composerpm__variant_arch__variant__compose__compose_id',
                                    distinct=True)
+    srpm_commit_hash = MultiValueFilter()
+    srpm_commit_branch = MultiValueFilter()
     linked_release = MultiValueFilter(name='linked_releases__release_id', distinct=True)
     built_for_release = MultiValueFilter(name='built_for_release__release_id', distinct=True)
     provides = django_filters.MethodFilter(action=partial(dependency_filter,

--- a/pdc/apps/package/serializers.py
+++ b/pdc/apps/package/serializers.py
@@ -70,7 +70,8 @@ class RPMSerializer(StrictSerializerMixin,
         model = models.RPM
         fields = ('id', 'name', 'version', 'epoch', 'release', 'arch', 'srpm_name',
                   'srpm_nevra', 'filename', 'linked_releases', 'linked_composes',
-                  'dependencies', 'built_for_release')
+                  'dependencies', 'built_for_release', 'srpm_commit_hash',
+                  'srpm_commit_branch')
 
     def create(self, validated_data):
         dependencies = validated_data.pop('dependencies', [])

--- a/pdc/apps/package/tests.py
+++ b/pdc/apps/package/tests.py
@@ -561,6 +561,7 @@ class RPMDepsAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
                 'release': '4.b1', 'arch': 'x86_64', 'srpm_name': 'bash',
                 'filename': 'bash-1.2.3-4.b1.x86_64.rpm', "built_for_release": None,
                 'linked_releases': [], 'srpm_nevra': 'fake_bash-0:1.2.3-4.b1.src',
+                'srpm_commit_hash': '', 'srpm_commit_branch': '',
                 'dependencies': {'requires': ['required-package'],
                                  'obsoletes': ['obsolete-package'],
                                  'suggests': ['suggested-package >= 1.0.0'],
@@ -910,6 +911,7 @@ class RPMAPIRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
                        "srpm_name": "bash", "srpm_nevra": "bash-0:1.2.3-4.b1.src",
                        "filename": "bash-1.2.3-4.b1.x86_64.rpm", "linked_releases": [],
                        "built_for_release": "release-1.0",
+                       "srpm_commit_hash": None, "srpm_commit_branch": None,
                        "linked_composes": ["compose-1"], "dependencies": self.empty_deps}
         self.assertEqual(response.data, expect_data)
 
@@ -922,14 +924,15 @@ class RPMAPIRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         url = reverse('rpms-list')
         data = {"name": "fake_bash", "version": "1.2.3", "epoch": 0, "release": "4.b1", "arch": "x86_64",
                 "srpm_name": "bash", "filename": "bash-1.2.3-4.b1.x86_64.rpm", "linked_releases": ['release-1.0'],
-                "srpm_nevra": "fake_bash-0:1.2.3-4.b1.src"}
+                "srpm_nevra": "fake_bash-0:1.2.3-4.b1.src", "srpm_commit_hash": "bash", "srpm_commit_branch": "master"}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         expected_response_data = {"id": 4, 'linked_composes': [],
                                   "name": "fake_bash", "version": "1.2.3", "epoch": 0, "release": "4.b1",
                                   "arch": "x86_64", "srpm_name": "bash", "filename": "bash-1.2.3-4.b1.x86_64.rpm",
                                   "linked_releases": ['release-1.0'], "srpm_nevra": "fake_bash-0:1.2.3-4.b1.src",
-                                  "built_for_release": None, "dependencies": self.empty_deps}
+                                  "built_for_release": None, "dependencies": self.empty_deps, "srpm_commit_hash": "bash",
+                                  "srpm_commit_branch": "master"}
         self.assertEqual(response.data, expected_response_data)
         self.assertNumChanges([1])
 
@@ -944,7 +947,8 @@ class RPMAPIRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
                                   "name": "fake_bash", "version": "1.2.3", "epoch": 0, "release": "4.b1",
                                   "arch": "x86_64", "srpm_name": "bash", "filename": "bash-1.2.3-4.b1.x86_64.rpm",
                                   "linked_releases": ['release-1.0'], "srpm_nevra": "fake_bash-0:1.2.3-4.b1.src",
-                                  "built_for_release": "release-1.0", "dependencies": self.empty_deps}
+                                  "built_for_release": "release-1.0", "dependencies": self.empty_deps,
+                                  "srpm_commit_hash": None, "srpm_commit_branch": None}
         self.assertEqual(response.data, expected_response_data)
         self.assertNumChanges([1])
 
@@ -1005,6 +1009,7 @@ class RPMAPIRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
     def test_update_rpm(self):
         data = {"name": "fake_bash", "version": "1.2.3", "epoch": 0, "release": "4.b1", "arch": "x86_64",
                 "srpm_name": "bash", "filename": "bash-1.2.3-4.b1.x86_64.rpm", "linked_releases": ['release-1.0'],
+                "srpm_commit_hash": None, "srpm_commit_branch": None,
                 "srpm_nevra": "fake_bash-0:1.2.3-4.b1.src", "built_for_release": 'release-2.0'}
         url = reverse('rpms-detail', args=[1])
         response = self.client.put(url, data, format='json')

--- a/pdc/apps/tree/filters.py
+++ b/pdc/apps/tree/filters.py
@@ -44,10 +44,11 @@ class UnreleasedVariantFilter(django_filters.FilterSet):
     runtime_dep_stream  = MultiValueFilter(name='runtime_deps__stream', distinct=True)
     build_dep_name      = MultiValueFilter(name='build_deps__dependency', distinct=True)
     build_dep_stream    = MultiValueFilter(name='build_deps__stream', distinct=True)
+    component_name      = MultiValueFilter(name='rpms__srpm_name', distinct=True)
 
     class Meta:
         model = UnreleasedVariant
         fields = ('variant_id', 'variant_uid', 'variant_name', 'variant_type',
                   'variant_version', 'variant_release', 'koji_tag',
                   'modulemd', 'runtime_dep_name', 'runtime_dep_stream',
-                  'build_dep_name', 'build_dep_stream')
+                  'build_dep_name', 'build_dep_stream', 'component_name')

--- a/pdc/apps/tree/filters.py
+++ b/pdc/apps/tree/filters.py
@@ -6,7 +6,7 @@
 
 import django_filters
 
-from pdc.apps.common.filters import CaseInsensitiveBooleanFilter
+from pdc.apps.common.filters import CaseInsensitiveBooleanFilter, MultiValueFilter
 from .models import (Tree, UnreleasedVariant)
 
 
@@ -40,9 +40,14 @@ class UnreleasedVariantFilter(django_filters.FilterSet):
     variant_release     = django_filters.CharFilter(name='variant_release', lookup_type='iexact')
     active              = CaseInsensitiveBooleanFilter()
     koji_tag            = django_filters.CharFilter(name='koji_tag', lookup_type='iexact')
+    runtime_dep_name    = MultiValueFilter(name='runtime_deps__dependency', distinct=True)
+    runtime_dep_stream  = MultiValueFilter(name='runtime_deps__stream', distinct=True)
+    build_dep_name      = MultiValueFilter(name='build_deps__dependency', distinct=True)
+    build_dep_stream    = MultiValueFilter(name='build_deps__stream', distinct=True)
 
     class Meta:
         model = UnreleasedVariant
         fields = ('variant_id', 'variant_uid', 'variant_name', 'variant_type',
                   'variant_version', 'variant_release', 'koji_tag',
-                  'modulemd', 'runtime_deps', 'build_deps')
+                  'modulemd', 'runtime_dep_name', 'runtime_dep_stream',
+                  'build_dep_name', 'build_dep_stream')

--- a/pdc/apps/tree/fixtures/test/rpm.json
+++ b/pdc/apps/tree/fixtures/test/rpm.json
@@ -1,0 +1,44 @@
+[
+  {
+    "model": "package.RPM",
+    "pk": 1,
+    "fields": {
+      "name": "bash",
+      "epoch": 0,
+      "version": "1.2.3",
+      "release": "4.b1",
+      "arch": "x86_64",
+      "srpm_name": "bash",
+      "srpm_nevra": "bash-0:1.2.3-4.b1.src",
+      "filename": "bash-1.2.3-4.b1.x86_64.rpm"
+    }
+  },
+  {
+    "model": "package.RPM",
+    "pk": 2,
+    "fields": {
+      "name": "bash-doc",
+      "epoch": 0,
+      "version": "1.2.3",
+      "release": "4.b2",
+      "arch": "x86_64",
+      "srpm_name": "bash",
+      "srpm_nevra": "bash-0:1.2.3-4.b2.src",
+      "filename": "bash-doc-1.2.3-4.b2.x86_64.rpm"
+    }
+  },
+  {
+    "model": "package.RPM",
+    "pk": 3,
+    "fields": {
+      "name": "bash-other",
+      "epoch": 0,
+      "version": "1.2.3",
+      "release": "4",
+      "arch": "src",
+      "srpm_name": "bash",
+      "srpm_nevra": null,
+      "filename": "bash-other-1.2.3-4.x86_64.rpm"
+    }
+  }
+]

--- a/pdc/apps/tree/migrations/0006_unreleasedvariant_rpms.py
+++ b/pdc/apps/tree/migrations/0006_unreleasedvariant_rpms.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('package', '0013_set_default_subvariant_to_empty_string'),
+        ('tree', '0005_unreleasedvariant_active'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='unreleasedvariant',
+            name='rpms',
+            field=models.ManyToManyField(to='package.RPM'),
+        ),
+    ]

--- a/pdc/apps/tree/models.py
+++ b/pdc/apps/tree/models.py
@@ -4,6 +4,7 @@
 # http://opensource.org/licenses/MIT
 from django.db import models
 from jsonfield import JSONField
+from pdc.apps.package.models import RPM
 
 
 class UnreleasedVariant(models.Model):
@@ -18,6 +19,7 @@ class UnreleasedVariant(models.Model):
     active              = models.BooleanField(default=False)
     koji_tag            = models.CharField(max_length=300, blank=False)
     modulemd            = models.TextField(blank=False)
+    rpms                = models.ManyToManyField(RPM)
 
     class Meta:
         ordering = ("variant_uid", "variant_version", "variant_release")
@@ -29,7 +31,7 @@ class UnreleasedVariant(models.Model):
         return u"%s" % (self.variant_uid, )
 
     def export(self):
-        return {
+        result = {
             'variant_id': self.variant_id,
             'variant_uid': self.variant_uid,
             'variant_name': self.variant_name,
@@ -42,6 +44,13 @@ class UnreleasedVariant(models.Model):
             'runtime_deps': [v.dependency for v in self.runtime_deps.all()],
             'build_deps': [v.dependency for v in self.build_deps.all()],
         }
+
+        result["rpms"] = []
+        objects = self.rpms.all()
+        for obj in objects:
+            result["rpms"].append(obj.export())
+
+        return result
 
 
 class VariantDependency(models.Model):

--- a/pdc/apps/tree/tests.py
+++ b/pdc/apps/tree/tests.py
@@ -51,6 +51,7 @@ class TreeAPITestCase(APITestCase):
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+
     def test_create_two_variants_query_by_active(self):
         url = reverse('unreleasedvariant-list')
         data = {
@@ -79,3 +80,60 @@ class TreeAPITestCase(APITestCase):
         results = json.loads(response.content)
         self.assertEqual(results['count'], 1)
         self.assertEqual(results['results'][0]['koji_tag'], 'module-core-0-2')
+
+    def test_filter_build_deps(self):
+        url = reverse('unreleasedvariant-list')
+
+        # Add variant with 'base-runtime-master' build-dep.
+        data = {
+            'variant_id': "core", 'variant_uid': "Core",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'koji_tag': "module-core-0-1", 'modulemd': 'foobar',
+            'build_deps': [{'dependency':'base-runtime', 'stream': 'master'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Add variant with 'base-runtime-f26' build-dep.
+        data = {
+            'variant_id': "core3", 'variant_uid': "Core3",
+            'variant_name': "Core3", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'koji_tag': "module-core3-0-1", 'modulemd': 'foobar',
+            'build_deps': [{'dependency':'base-runtime', 'stream': 'f26'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Add variant with 'bootstrap-master' build-dep.
+        data = {
+            'variant_id': "core2", 'variant_uid': "Core2",
+            'variant_name': "Core2", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'koji_tag': "module-core2-0-1", 'modulemd': 'foobar',
+            'build_deps': [{'dependency':'bootstrap', 'stream': 'master'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Try to get unknown build-dep
+        data = {'build_dep_name': "unknown"}
+        response = self.client.get(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 0)
+
+        # Try to get base-runtime build-dep
+        data = {'build_dep_name': "base-runtime"}
+        response = self.client.get(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
+
+        # Try to get base-runtime-master build-dep
+        data = {'build_dep_name': "base-runtime",
+                'build_dep_stream': "master"}
+        response = self.client.get(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]["variant_uid"], "Core")


### PR DESCRIPTION
This is needed by Freshmaker to query all the modules depending on another module.