### PR TITLE
Allow filtering modules by RPM's srpm_commit_branch.

### DIFF
--- a/pdc/apps/tree/filters.py
+++ b/pdc/apps/tree/filters.py
@@ -45,10 +45,12 @@ class UnreleasedVariantFilter(django_filters.FilterSet):
     build_dep_name      = MultiValueFilter(name='build_deps__dependency', distinct=True)
     build_dep_stream    = MultiValueFilter(name='build_deps__stream', distinct=True)
     component_name      = MultiValueFilter(name='rpms__srpm_name', distinct=True)
+    component_branch    = MultiValueFilter(name='rpms__srpm_commit_branch', distinct=True)
 
     class Meta:
         model = UnreleasedVariant
         fields = ('variant_id', 'variant_uid', 'variant_name', 'variant_type',
                   'variant_version', 'variant_release', 'koji_tag',
                   'modulemd', 'runtime_dep_name', 'runtime_dep_stream',
-                  'build_dep_name', 'build_dep_stream', 'component_name')
+                  'build_dep_name', 'build_dep_stream', 'component_name',
+                  'component_branch')


### PR DESCRIPTION
This can make it easy for Freshmaker to querying modules when rpm spec in dist-git updated as we cares about the branch too.